### PR TITLE
Enhance Transit Gateway Terraform code with additional outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,19 @@
+output "tgw_attachment_id" {
+  value = aws_ec2_transit_gateway_vpc_attachment.tgw_attachment.id
+}
+
+output "tgw_attachment_subnet_ids" {
+  value = aws_ec2_transit_gateway_vpc_attachment.tgw_attachment.subnet_ids
+}
+
+output "tgw_attachment_vpc_id" {
+  value = aws_ec2_transit_gateway_vpc_attachment.tgw_attachment.vpc_id
+}
+
+output "tgw_attachment_tgw_id" {
+  value = aws_ec2_transit_gateway_vpc_attachment.tgw_attachment.transit_gateway_id
+}
+
+output "tgw_attachment_route_table_ids" {
+  value = aws_ec2_transit_gateway_vpc_attachment.tgw_attachment.route_table_ids
+}


### PR DESCRIPTION
This PR adds some useful output values for the `aws_ec2_transit_gateway_vpc_attachment` resource and a code snippet for outputting the routes for a specific transit gateway route table.

The outputs.tf file now includes the following output values for the `aws_ec2_transit_gateway_vpc_attachment` resource:

- tgw_attachment_id
- tgw_attachment_subnet_ids
- tgw_attachment_vpc_id
- tgw_attachment_tgw_id
- tgw_attachment_route_table_ids

This is so we can depend on the TGW attachment for adding routes